### PR TITLE
 Fixed bug in onFinished event execution control

### DIFF
--- a/lib/timer_count_down.dart
+++ b/lib/timer_count_down.dart
@@ -143,10 +143,11 @@ class _CountdownState extends State<Countdown> {
 
             if (widget.onFinished != null) {
               widget.onFinished!();
-            }
-            _onFinishedExecuted = true;
+              this._onFinishedExecuted = true;
+            }            
             widget.controller?.isCompleted = true;
           } else {
+            this._onFinishedExecuted = false;
             setState(() {
               _currentMicroSeconds =
                   _currentMicroSeconds - widget.interval.inMicroseconds;
@@ -157,8 +158,8 @@ class _CountdownState extends State<Countdown> {
     } else if (!this._onFinishedExecuted) {
       if (widget.onFinished != null) {
         widget.onFinished!();
-      }
-      this._onFinishedExecuted = true;
+        this._onFinishedExecuted = true;
+      }      
       widget.controller?.isCompleted = true;
     }
   }


### PR DESCRIPTION
When using the component in a chained action, I noticed a problem in the flag that controls whether the _onFinishedExecuted event was executed. 
Generating a death lock. 
The correction performed links the flag with the event and adds the false assignment during the current execution of the Timer.